### PR TITLE
[wip][feat] completion cache, but very much just a PoC right now

### DIFF
--- a/okcli/completion_cache.py
+++ b/okcli/completion_cache.py
@@ -1,0 +1,18 @@
+import hashlib
+from os import path
+
+def completion_filename(user, host):
+    return hashlib.md5(("%s%s" % (user, host)).encode('utf-8')).hexdigest()
+
+def completion_cache_dir(config):
+    return path.join(path.dirname(config.filename), '.okcli_cache')
+
+def completion_cache_file(user, host, config):
+    return path.join(completion_cache_dir(config), completion_filename(user, host))
+
+def existing_completion_cache_file(user, host, config):
+    maybe_file = completion_cache_file(user, host, config)
+    if path.isfile(maybe_file):
+        return maybe_file
+    else:
+        return None

--- a/okcli/okclirc
+++ b/okcli/okclirc
@@ -5,6 +5,11 @@
 # possible completions will be listed.
 smart_completion = True
 
+# Caches completions until they have been refreshed.
+# This makes sense when loading completions is not instantaneous
+# (depends on the amount of things in the database)
+cache_completions = False
+
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple


### PR DESCRIPTION
Hi,

As discussed #6 here's a draft at completion caching.
Definitely don't merge it for now.

Want to get some early feedback since I haven't written python in a while.
I've just implemented the config file switch for now, it might actually be good enough because IMHO there's no significant downside to activating the completion cache always. If fetching the completions is fast you won't notice and if it's not you want the cache :stuck_out_tongue: 

The usage of pickle might be debatable, since it can be used to execute malicious code (some other thing could tamper with the cache, but then your machine is already compromised, etc). Pickle has the advantage that it just works on python platforms and it doesn't care about the structure of the completer.

I've also just tested this by setting the pythonpath and running it locally. `setup.py test` tries to build a wheel and fails for some reason, and I haven't found instructions on how to run the existing tests, but I'm partial to adding some.


Other stuff I'm not sure about:
- does it make sense to change the "refreshing completions..." output? I'm not sure.
- more error handling to be sure in case something blows up (e.G. user corrupts the pickled file)